### PR TITLE
Update sbt plugins and adjust publishing settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,11 +17,17 @@ inThisBuild(
     useCoursier := false,
     scalaVersion := mainScala,
 //    crossScalaVersions := allScala,
+    sbtPluginPublishLegacyMavenStyle := false,
     Test / parallelExecution := false,
     Test / fork := true,
     run / fork := true,
-    sonatypeCredentialHost := "s01.oss.sonatype.org",
-    sonatypeRepository := "https://s01.oss.sonatype.org/service/local",
+    publishTo := {
+      val centralSnapshots =
+        "https://central.sonatype.com/repository/maven-snapshots/"
+      if (isSnapshot.value) Some("central-snapshots" at centralSnapshots)
+      else localStaging.value
+    },
+    versionScheme := Some("early-semver"),
     pgpPublicRing := file("/tmp/public.asc"),
     pgpSecretRing := file("/tmp/secret.asc"),
     pgpPassphrase := sys.env.get("PGP_PASSWORD").map(_.toArray),
@@ -57,9 +63,5 @@ lazy val plugin = project
     moduleName := "sbt-plantuml",
     libraryDependencies += "net.sourceforge.plantuml" % "plantuml" % "1.2025.3",
     libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.19" % Test,
-    pluginCrossBuild / sbtVersion := "1.10.7",
-    addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.0"),
-    addSbtPlugin("com.github.sbt" % "sbt-git" % "2.1.0"),
-    addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.12.2"),
-    addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.3.1")
+    pluginCrossBuild / sbtVersion := "1.11.1"
   )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,2 +1,7 @@
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.4")
-addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.9.3")
+// scalafmt: { maxColumn = 120, style = defaultWithAlign }
+
+addSbtPlugin("org.scalameta"  % "sbt-scalafmt"   % "2.5.4")
+addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.11.1")
+addSbtPlugin("com.github.sbt" % "sbt-dynver"     % "5.1.0")
+addSbtPlugin("com.github.sbt" % "sbt-git"        % "2.1.0")
+addSbtPlugin("com.github.sbt" % "sbt-pgp"        % "2.3.1")


### PR DESCRIPTION
Updates sbt plugins and publishing settings.

This commit updates several sbt plugins to ensure compatibility with newer versions. It also adjusts publishing settings to use Sonatype's Maven snapshots repository for snapshot releases. Additionally, it adds support for early semantic versioning. These changes aim to improve the project's build process and simplify its deployment pipeline.